### PR TITLE
support for profile class names to be also be called with :: prefix

### DIFF
--- a/lib/puppet-lint/plugins/check_roles_and_profiles.rb
+++ b/lib/puppet-lint/plugins/check_roles_and_profiles.rb
@@ -42,7 +42,7 @@ PuppetLint.new_check(:roles_resource_declaration) do
   def check
     class_indexes.select {|c| c[:name_token].value.start_with?('role')}.each do |klass|
       resource_indexes.select { |r| r[:start] > klass[:start] and r[:end] < klass[:end] }.each do |resource|
-        if  resource[:type].type != :CLASS or !resource[:type].next_code_token.next_code_token.value.start_with?('profiles')
+        if  resource[:type].type != :CLASS or (resource[:type].next_code_token.next_code_token.value =~ /^(::)?profiles/) == nil
           notify :warning, {
             :message => 'expected no resource declaration',
             :line    => resource[:type].line,
@@ -51,7 +51,7 @@ PuppetLint.new_check(:roles_resource_declaration) do
         end
       end
       tokens[klass[:start]..klass[:end]].select { |t| t.value == 'include' }.each do |token|
-        if !token.next_code_token.value.start_with?('profiles')
+        if (token.next_code_token.value =~ /^(::)?profiles/) == nil
           notify :warning, {
             :message => 'expected no resource declaration',
             :line    => token.line,

--- a/spec/puppet-lint/plugins/check_roles_resource_declaration_spec.rb
+++ b/spec/puppet-lint/plugins/check_roles_resource_declaration_spec.rb
@@ -49,6 +49,20 @@ class roles::foo {
       end
     end
 
+    context 'with ::profile declaration' do
+      let(:code) do
+        <<-EOS
+class roles::foo {
+  class { '::profiles::bar': }
+}
+        EOS
+      end
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
     context 'with any class declaration' do
       let(:code) do
         <<-EOS
@@ -81,6 +95,20 @@ class roles::foo {
       end
     end
 
+    context 'with ::profile inclusion' do
+      let(:code) do
+        <<-EOS
+class roles::foo {
+  include ::profiles::bar
+}
+        EOS
+      end
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
     context 'with any class inclusion' do
       let(:code) do
         <<-EOS
@@ -100,7 +128,7 @@ class roles::foo {
     end
 
     context 'with one resource' do
-      let(:code) do 
+      let(:code) do
         <<-EOS
 class roles::foo {
   include profiles::bar
@@ -119,7 +147,7 @@ class roles::foo {
     end
 
     context 'with two resources' do
-      let(:code) do 
+      let(:code) do
         <<-EOS
 class roles::foo {
   include profiles::bar


### PR DESCRIPTION
technically all of the following should be valid:

roles::test {
  include profiles::one
  include ::profiles::two
  class { 'profiles::three': }
  class { '::profiles::four': }
}
