### PR TITLE
Allow class names to be prefixed with '::'

### DIFF
--- a/lib/puppet-lint/plugins/check_roles_and_profiles.rb
+++ b/lib/puppet-lint/plugins/check_roles_and_profiles.rb
@@ -8,7 +8,7 @@ PuppetLint.new_check(:node_definition) do
     node_indexes.each do |node|
       role_already_declared = false
       resource_indexes.select { |r| r[:start] > node[:start] and r[:end] < node[:end] }.each do |resource|
-        if resource[:type].type != :CLASS or !resource[:type].next_code_token.next_code_token.value.start_with?('roles') or role_already_declared == true
+        if resource[:type].type != :CLASS or (resource[:type].next_code_token.next_code_token.value =~ /^(::)?role/).nil? or role_already_declared == true
           notify :warning, {
             :message => 'expected only one role declaration',
             :line    => resource[:type].line,
@@ -24,7 +24,7 @@ end
 
 PuppetLint.new_check(:roles_class_params) do
   def check
-    class_indexes.select {|c| c[:name_token].value.start_with?('roles')}.each do |klass|
+    class_indexes.select {|c| c[:name_token].value.start_with?('role')}.each do |klass|
       unless klass[:param_tokens].nil?
         klass[:param_tokens].select {|t|t.type == :VARIABLE }.each do |token|
           notify :warning, {
@@ -42,7 +42,7 @@ PuppetLint.new_check(:roles_resource_declaration) do
   def check
     class_indexes.select {|c| c[:name_token].value.start_with?('role')}.each do |klass|
       resource_indexes.select { |r| r[:start] > klass[:start] and r[:end] < klass[:end] }.each do |resource|
-        if  resource[:type].type != :CLASS or !resource[:type].next_code_token.next_code_token.value.start_with?('profile')
+        if  resource[:type].type != :CLASS or (resource[:type].next_code_token.next_code_token.value =~ /^(::)?profile/).nil?
           notify :warning, {
             :message => 'expected no resource declaration',
             :line    => resource[:type].line,
@@ -51,7 +51,7 @@ PuppetLint.new_check(:roles_resource_declaration) do
         end
       end
       tokens[klass[:start]..klass[:end]].select { |t| t.value == 'include' }.each do |token|
-        if !token.next_code_token.value.start_with?('profile')
+        if (token.next_code_token.value =~ /^(::)?profile/).nil?
           notify :warning, {
             :message => 'expected no resource declaration',
             :line    => token.line,

--- a/spec/puppet-lint/plugins/check_roles_class_params_spec.rb
+++ b/spec/puppet-lint/plugins/check_roles_class_params_spec.rb
@@ -70,7 +70,7 @@ class roles::foo(
     context 'with two parameters' do
       let(:code) do
         <<-EOS
-class roles::foo(
+class role::foo(
   $bar = 'bar',
   $baz = 'baz',
 ) {

--- a/spec/puppet-lint/plugins/check_roles_resource_declaration_spec.rb
+++ b/spec/puppet-lint/plugins/check_roles_resource_declaration_spec.rb
@@ -49,6 +49,19 @@ class roles::foo {
       end
     end
 
+    context 'with ::profile declaration' do
+      let(:code) do
+        <<-EOS
+class roles::foo {
+  class { '::profile::bar': }
+}
+        EOS
+      end
+       it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
     context 'with any class declaration' do
       let(:code) do
         <<-EOS
@@ -81,6 +94,19 @@ class roles::foo {
       end
     end
 
+    context 'with ::profile inclusion' do
+      let(:code) do
+        <<-EOS
+class roles::foo {
+  include ::profile::bar
+}
+        EOS
+      end
+       it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+
     context 'with any class inclusion' do
       let(:code) do
         <<-EOS
@@ -100,7 +126,7 @@ class roles::foo {
     end
 
     context 'with one resource' do
-      let(:code) do 
+      let(:code) do
         <<-EOS
 class roles::foo {
   include profiles::bar
@@ -119,7 +145,7 @@ class roles::foo {
     end
 
     context 'with two resources' do
-      let(:code) do 
+      let(:code) do
         <<-EOS
 class roles::foo {
   include profiles::bar


### PR DESCRIPTION
This partly a rebase of #2 that merges cleanly. Also allow singular role::* class names.

